### PR TITLE
[FIX] Give age columns a Transformation key

### DIFF
--- a/bagel_dictionary_schema.json
+++ b/bagel_dictionary_schema.json
@@ -58,15 +58,6 @@
             "type": "string"
           }
         },
-        "IsPartOf": {
-          "title": "Ispartof",
-          "description": "If the column is a subscale or item of an assessment tool then the assessment tool should be specified here.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Identifier"
-            }
-          ]
-        },
         "Levels": {
           "title": "Levels",
           "description": "For categorical variables: An object of values (keys) in the column and the semanticterm (URI and label) they are unambiguously mapped to.",
@@ -79,11 +70,88 @@
       "required": [
         "IsAbout",
         "Levels"
-      ]
+      ],
+      "additionalProperties": false
     },
     "ContinuousNeurobagel": {
       "title": "ContinuousNeurobagel",
       "description": "A Neurobagel annotation for a continuous column",
+      "type": "object",
+      "properties": {
+        "IsAbout": {
+          "title": "Isabout",
+          "description": "The concept or controlled term that describes this column",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Identifier"
+            }
+          ]
+        },
+        "MissingValues": {
+          "title": "Missingvalues",
+          "description": "A list of unique values that represent invalid responses, typos, or missing data",
+          "default": [],
+          "uniqueItems": true,
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Transformation": {
+          "title": "Transformation",
+          "description": "For continuous columns this field can be used to describea transformation that can be applied to the values in thiscolumn in order to match the desired format of a standardizeddata element referenced in the IsAbout attribute.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Identifier"
+            }
+          ]
+        }
+      },
+      "required": [
+        "IsAbout",
+        "Transformation"
+      ],
+      "additionalProperties": false
+    },
+    "IdentifierNeurobagel": {
+      "title": "IdentifierNeurobagel",
+      "description": "A Neurobagel annotation for an identifier column",
+      "type": "object",
+      "properties": {
+        "IsAbout": {
+          "title": "Isabout",
+          "description": "The concept or controlled term that describes this column",
+          "allOf": [
+            {
+              "$ref": "#/definitions/Identifier"
+            }
+          ]
+        },
+        "MissingValues": {
+          "title": "Missingvalues",
+          "description": "A list of unique values that represent invalid responses, typos, or missing data",
+          "default": [],
+          "uniqueItems": true,
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Identifies": {
+          "title": "Identifies",
+          "description": "For identifier columns, the type of observation uniquely identified by this column.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "IsAbout",
+        "Identifies"
+      ],
+      "additionalProperties": false
+    },
+    "ToolNeurobagel": {
+      "title": "ToolNeurobagel",
+      "description": "A Neurobagel annotation for an assessment tool column",
       "type": "object",
       "properties": {
         "IsAbout": {
@@ -113,20 +181,13 @@
               "$ref": "#/definitions/Identifier"
             }
           ]
-        },
-        "Transformation": {
-          "title": "Transformation",
-          "description": "For continuous columns this field can be used to describea transformation that can be applied to the values in thiscolumn in order to match the desired format of a standardizeddata element referenced in the IsAbout attribute.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Identifier"
-            }
-          ]
         }
       },
       "required": [
-        "IsAbout"
-      ]
+        "IsAbout",
+        "IsPartOf"
+      ],
+      "additionalProperties": false
     },
     "ContinuousColumn": {
       "title": "ContinuousColumn",
@@ -147,6 +208,12 @@
             },
             {
               "$ref": "#/definitions/ContinuousNeurobagel"
+            },
+            {
+              "$ref": "#/definitions/IdentifierNeurobagel"
+            },
+            {
+              "$ref": "#/definitions/ToolNeurobagel"
             }
           ]
         },
@@ -179,6 +246,12 @@
             },
             {
               "$ref": "#/definitions/ContinuousNeurobagel"
+            },
+            {
+              "$ref": "#/definitions/IdentifierNeurobagel"
+            },
+            {
+              "$ref": "#/definitions/ToolNeurobagel"
             }
           ]
         },

--- a/process_annotation_to_dict.py
+++ b/process_annotation_to_dict.py
@@ -94,6 +94,7 @@ def describe_level(term: str) -> dict:
 def describe_continuous(df: pd.DataFrame) -> dict:
     t_url, t_label = get_transform_heuristic(df)
     if not t_url:
+        print(df["dataset"].item(),  "has no age")
         return {}
     
     return {
@@ -173,7 +174,6 @@ def process_dict(ds_df: pd.DataFrame, user_dict: dict) -> dict:
         elif is_tool(col_df):
             user_dict.setdefault(col, {}).update(**describe_tool(col_df))
         else:
-            print("Yes age")
             user_dict.setdefault(col, {}).update(**describe_continuous(col_df))
 
     user_dict = add_description(data_dict=user_dict)

--- a/process_annotation_to_dict.py
+++ b/process_annotation_to_dict.py
@@ -43,6 +43,7 @@ def fetch_data_dictionary(dataset: str) -> dict:
 
 
 def get_transform_heuristic(df: pd.DataFrame) -> Tuple[str]:
+    """Returns Neurobagel transformation term and short label from parsed type"
     col_type = get_col_rows(df)["type"].item()
     if col_type == "float64":
         return ("nb:float", "float data")

--- a/process_annotation_to_dict.py
+++ b/process_annotation_to_dict.py
@@ -13,7 +13,7 @@ with (MYPATH / "bagel_dictionary_schema.json").open("r") as f:
 
 def is_discrete(df: pd.DataFrame) -> bool:
     """True if each row in dataframe describes a discrete value in a column."""
-    return  not df.is_row.all()
+    return not df.is_row.all()
 
 
 def is_dropped(df: pd.DataFrame) -> bool:
@@ -30,7 +30,7 @@ def get_ds_path(dataset: str) -> Path:
 
 
 def get_dict_path(dataset: str) -> Path:
-    return get_ds_path(dataset) / "participants.json";
+    return get_ds_path(dataset) / "participants.json"
 
 
 def fetch_data_dictionary(dataset: str) -> dict:
@@ -40,8 +40,8 @@ def fetch_data_dictionary(dataset: str) -> dict:
         return data_dict
     else:
         return {}
-    
-    
+
+
 def get_transform_heuristic(df: pd.DataFrame) -> Tuple[str]:
     col_type = get_col_rows(df)["type"].item()
     if col_type == "float64":
@@ -54,19 +54,19 @@ def get_transform_heuristic(df: pd.DataFrame) -> Tuple[str]:
         return ("nb:euro", "european decimal value")
     else:
         return ("", "")
-    
-    
+
+
 def describe_continuous(df: pd.DataFrame) -> dict:
     return {
         "Annotations": {
             "IsAbout": {
                 "TermURL": get_col_rows(df)["controlled_term"].item(),
-                "Label": ""
+                "Label": "",
             }
         }
     }
-    
-    
+
+
 def get_col_rows(df: pd.DataFrame) -> pd.DataFrame:
     return df.query("is_row == True")
 
@@ -74,37 +74,35 @@ def get_col_rows(df: pd.DataFrame) -> pd.DataFrame:
 def get_level_rows(df: pd.DataFrame) -> pd.DataFrame:
     return df.query("is_row == False")
 
-    
-def describe_level(term: str) -> dict:
-    return {
-            "TermURL": term,
-            "Label": ""
-        }
 
-    
+def describe_level(term: str) -> dict:
+    return {"TermURL": term, "Label": ""}
+
+
 def describe_discrete(df: pd.DataFrame) -> dict:
     return {
         "Annotations": {
             "IsAbout": {
                 "TermURL": get_col_rows(df)["controlled_term"].item(),
-                "Label": ""
+                "Label": "",
             },
             "Levels": {
-                row.value: describe_level(row.controlled_term) for _, row in get_level_rows(df).iterrows()
-            }
+                row.value: describe_level(row.controlled_term)
+                for _, row in get_level_rows(df).iterrows()
+            },
         }
     }
-    
+
 
 def describe_tool(df: pd.DataFrame) -> dict:
     return {
         "IsPartOf": {
             "TermURL": get_col_rows(df)["isPartOf"].item(),
-            "Label": ""
+            "Label": "",
         }
     }
-    
-    
+
+
 def add_description(data_dict: dict) -> dict:
     """
     Given a column, adds an empty description if none is present.
@@ -112,13 +110,14 @@ def add_description(data_dict: dict) -> dict:
     """
     # TODO: This function is a hacky fix for bad data dictionaries in the input data and should be removed
     for key, column in data_dict.items():
-        
         if "Description" not in column.keys():
-            column["Description"] = "There should have been a description here, but there wasn't. :("
+            column[
+                "Description"
+            ] = "There should have been a description here, but there wasn't. :("
         data_dict[key].update(**column)
     return data_dict
-    
-    
+
+
 def is_valid_dict(data_dict: dict) -> bool:
     """Returns True for valid Neurobagel data dictionary"""
     try:
@@ -126,51 +125,53 @@ def is_valid_dict(data_dict: dict) -> bool:
         return True
     except jsonschema.ValidationError:
         return False
-    
-    
+
+
 def write_data_dict(data_dict: dict, path: Path, name: str) -> None:
     path.mkdir(exist_ok=True)
     with (path / f"{name}.json").open("w") as f:
         json.dump(data_dict, f, indent=2)
-    
+
 
 def process_dict(ds_df: pd.DataFrame, user_dict: dict) -> dict:
     """
-    Take an existing data dictionary (can be empty) and 
+    Take an existing data dictionary (can be empty) and
     add what we have to it so that it gets more detailed.
     """
     for col, col_df in ds_df.groupby("column"):
-            
         if is_dropped(col_df):
             continue
         if is_discrete(col_df):
-            user_dict.setdefault(col, {}).update(**describe_discrete(col_df))    
+            user_dict.setdefault(col, {}).update(**describe_discrete(col_df))
         else:
             user_dict.setdefault(col, {}).update(**describe_continuous(col_df))
-        
-        if is_tool(col_df):
-            user_dict[col].setdefault("Annotations", {}).update(**describe_tool(col_df))
-        
-    user_dict = add_description(data_dict=user_dict)
-    
-    return user_dict
 
+        if is_tool(col_df):
+            user_dict[col].setdefault("Annotations", {}).update(
+                **describe_tool(col_df)
+            )
+
+    user_dict = add_description(data_dict=user_dict)
+
+    return user_dict
 
 
 def main():
     annotated = pd.read_csv(MYPATH / "outputs/annotated_levels.tsv", sep="\t")
-    
+
     for dataset, ds_df in annotated.groupby("dataset"):
-        
         data_dict = fetch_data_dictionary(dataset=dataset)
-        
+
         data_dict = process_dict(ds_df, data_dict)
-        
+
         if not is_valid_dict(data_dict):
             # TODO: make smarter choices about logging and warnings
             print("Uhoh, this is not a valid dict", dataset)
-        write_data_dict(data_dict, MYPATH / "outputs/data_dictionaries/", name=dataset)
+        write_data_dict(
+            data_dict, MYPATH / "outputs/data_dictionaries/", name=dataset
+        )
     print("Tada!")
+
 
 if __name__ == "__main__":
     main()

--- a/process_annotation_to_dict.py
+++ b/process_annotation_to_dict.py
@@ -26,7 +26,7 @@ def is_identifying(df: pd.DataFrame) -> bool:
 
 
 def is_tool(df: pd.DataFrame) -> bool:
-    return isinstance(get_col_rows(df)["isPartOf"].item(), str) and "cogatlas:" in get_col_rows(df)["isPartOf"].item()
+    return "cogatlas:" in str(get_col_rows(df)["isPartOf"].item())
 
 
 def get_ds_path(dataset: str) -> Path:

--- a/process_annotation_to_dict.py
+++ b/process_annotation_to_dict.py
@@ -26,7 +26,7 @@ def is_identifying(df: pd.DataFrame) -> bool:
 
 
 def is_tool(df: pd.DataFrame) -> bool:
-    return get_col_rows(df)["isPartOf"].item() != ""
+    return isinstance(get_col_rows(df)["isPartOf"].item(), str) and "cogatlas:" in get_col_rows(df)["isPartOf"].item()
 
 
 def get_ds_path(dataset: str) -> Path:
@@ -173,6 +173,7 @@ def process_dict(ds_df: pd.DataFrame, user_dict: dict) -> dict:
         elif is_tool(col_df):
             user_dict.setdefault(col, {}).update(**describe_tool(col_df))
         else:
+            print("Yes age")
             user_dict.setdefault(col, {}).update(**describe_continuous(col_df))
 
     user_dict = add_description(data_dict=user_dict)
@@ -190,7 +191,8 @@ def main():
 
         if not is_valid_dict(data_dict):
             # TODO: make smarter choices about logging and warnings
-            print("Uhoh, this is not a valid dict", dataset)
+            # print("Uhoh, this is not a valid dict", dataset)
+            pass
         write_data_dict(
             data_dict, MYPATH / "outputs/data_dictionaries/", name=dataset
         )

--- a/process_annotation_to_dict.py
+++ b/process_annotation_to_dict.py
@@ -69,11 +69,16 @@ def describe_level(term: str) -> dict:
 
 
 def describe_continuous(df: pd.DataFrame) -> dict:
+    t_url, t_label = get_transform_heuristic(df)
     return {
         "Annotations": {
             "IsAbout": {
                 "TermURL": get_col_rows(df)["controlled_term"].item(),
                 "Label": "",
+            },
+            "Transformation": {
+                "TermURL": t_url,
+                "Labels": t_label
             }
         }
     }

--- a/process_annotation_to_dict.py
+++ b/process_annotation_to_dict.py
@@ -70,18 +70,17 @@ def describe_level(term: str) -> dict:
 
 def describe_continuous(df: pd.DataFrame) -> dict:
     t_url, t_label = get_transform_heuristic(df)
-    return {
+    annotations = {
         "Annotations": {
             "IsAbout": {
                 "TermURL": get_col_rows(df)["controlled_term"].item(),
                 "Label": "",
-            },
-            "Transformation": {
-                "TermURL": t_url,
-                "Labels": t_label
             }
         }
     }
+    if t_url:
+       annotations["Annotations"].update(**{"Transformation": {"TermURL": t_url, "Label": t_label}})
+    return annotations
 
 
 def describe_discrete(df: pd.DataFrame) -> dict:

--- a/process_annotation_to_dict.py
+++ b/process_annotation_to_dict.py
@@ -43,7 +43,7 @@ def fetch_data_dictionary(dataset: str) -> dict:
 
 
 def get_transform_heuristic(df: pd.DataFrame) -> Tuple[str]:
-    """Returns Neurobagel transformation term and short label from parsed type"
+    """Returns Neurobagel transformation term and short label from parsed type"""
     col_type = get_col_rows(df)["type"].item()
     if col_type == "float64":
         return ("nb:float", "float data")

--- a/process_annotation_to_dict.py
+++ b/process_annotation_to_dict.py
@@ -76,6 +76,15 @@ def describe_isabout(term: str) -> dict:
                 "Label": "",
             }
     }
+    
+    
+def describe_identified(df: pd.DataFrame) -> dict:
+    return {
+        "Annotations": {
+        **describe_isabout(get_col_rows(df)["controlled_term"].item()),
+        "Identifies": "participant"
+        }
+    }
 
 
 def describe_level(term: str) -> dict:

--- a/process_annotation_to_dict.py
+++ b/process_annotation_to_dict.py
@@ -98,10 +98,7 @@ def describe_continuous(df: pd.DataFrame) -> dict:
 def describe_discrete(df: pd.DataFrame) -> dict:
     return {
         "Annotations": {
-            "IsAbout": {
-                "TermURL": get_col_rows(df)["controlled_term"].item(),
-                "Label": "",
-            },
+            **describe_isabout(get_col_rows(df)["controlled_term"].item()),
             "Levels": {
                 row.value: describe_level(row.controlled_term)
                 for _, row in get_level_rows(df).iterrows()
@@ -113,10 +110,7 @@ def describe_discrete(df: pd.DataFrame) -> dict:
 def describe_tool(df: pd.DataFrame) -> dict:
     return {
         "Annotations": {
-            "IsAbout": {
-                "TermURL": get_col_rows(df)["controlled_term"].item(),
-                "Label": "",
-            },
+            **describe_isabout(get_col_rows(df)["controlled_term"].item()),
             "IsPartOf": {
                 "TermURL": get_col_rows(df)["isPartOf"].item(),
                 "Label": "",

--- a/process_annotation_to_dict.py
+++ b/process_annotation_to_dict.py
@@ -56,17 +56,6 @@ def get_transform_heuristic(df: pd.DataFrame) -> Tuple[str]:
         return ("", "")
 
 
-def describe_continuous(df: pd.DataFrame) -> dict:
-    return {
-        "Annotations": {
-            "IsAbout": {
-                "TermURL": get_col_rows(df)["controlled_term"].item(),
-                "Label": "",
-            }
-        }
-    }
-
-
 def get_col_rows(df: pd.DataFrame) -> pd.DataFrame:
     return df.query("is_row == True")
 
@@ -77,6 +66,17 @@ def get_level_rows(df: pd.DataFrame) -> pd.DataFrame:
 
 def describe_level(term: str) -> dict:
     return {"TermURL": term, "Label": ""}
+
+
+def describe_continuous(df: pd.DataFrame) -> dict:
+    return {
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": get_col_rows(df)["controlled_term"].item(),
+                "Label": "",
+            }
+        }
+    }
 
 
 def describe_discrete(df: pd.DataFrame) -> dict:

--- a/process_annotation_to_dict.py
+++ b/process_annotation_to_dict.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import json
+from typing import Tuple
 
 import jsonschema
 import pandas as pd
@@ -39,6 +40,20 @@ def fetch_data_dictionary(dataset: str) -> dict:
         return data_dict
     else:
         return {}
+    
+    
+def get_transform_heuristic(df: pd.DataFrame) -> Tuple[str]:
+    col_type = get_col_rows(df)["type"].item()
+    if col_type == "float64":
+        return ("nb:float", "float data")
+    if col_type == "int64":
+        return ("nb:int", "integer data")
+    if col_type == "nb:bounded":
+        return ("nb:bounded", "bounded data")
+    if col_type == "nb:euro":
+        return ("nb:euro", "european decimal value")
+    else:
+        return ("", "")
     
     
 def describe_continuous(df: pd.DataFrame) -> dict:
@@ -98,7 +113,7 @@ def add_description(data_dict: dict) -> dict:
     # TODO: This function is a hacky fix for bad data dictionaries in the input data and should be removed
     for key, column in data_dict.items():
         
-        if not "Description" in column.keys():
+        if "Description" not in column.keys():
             column["Description"] = "There should have been a description here, but there wasn't. :("
         data_dict[key].update(**column)
     return data_dict

--- a/tests_proc_dict.py
+++ b/tests_proc_dict.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from process_annotation_to_dict import process_dict, get_transform_heuristic
+from process_annotation_to_dict import process_dict, get_transform_heuristic, describe_continuous
 
 
 @pytest.fixture
@@ -33,7 +33,7 @@ def continuous_annotation():
     return {
         "dataset": {10: "ds000002"},
         "column": {10: "age"},
-        "type": {10: "float"},
+        "type": {10: "float64"},
         "value": {10: ""},
         "is_row": {10: True},
         "description": {10: ""},
@@ -110,6 +110,20 @@ def test_bad_continuous_has_transformation(continuous_annotation, user_dict):
     result = process_dict(data, user_dict)
 
     assert result.get("age").get("Annotations").get("Transformation") is None
+
+
+def test_describe_continuous(continuous_annotation):
+    result = describe_continuous(pd.DataFrame(continuous_annotation))
+    assert result == {"Annotations": {
+        "IsAbout": {
+            "TermURL": "nb:Age",
+            "Label": "",
+        },
+        "Transformation": {
+            "TermURL": "nb:float",
+            "Label": "float data",
+            },
+    }}
 
 
 def test_partof_annotation_is_processed(tool_annotation, user_dict):

--- a/tests_proc_dict.py
+++ b/tests_proc_dict.py
@@ -102,14 +102,14 @@ def test_good_continuous_has_transformation(continuous_annotation, user_dict):
     )
 
 
-def test_bad_continuous_has_transformation(continuous_annotation, user_dict):
+def test_bad_continuous_lacks_transformation(continuous_annotation, user_dict):
     continuous_annotation.update(**{"type": {10: "nonsense_heuristic"}})
     data = pd.DataFrame(
         continuous_annotation
     )
     result = process_dict(data, user_dict)
 
-    assert result.get("age").get("Annotations").get("Transformation") is None
+    assert result.get("age").get("Annotations", {}).get("Transformation") is None
 
 
 def test_describe_continuous(continuous_annotation):

--- a/tests_proc_dict.py
+++ b/tests_proc_dict.py
@@ -103,8 +103,9 @@ def test_good_continuous_has_transformation(continuous_annotation, user_dict):
 
 
 def test_bad_continuous_has_transformation(continuous_annotation, user_dict):
+    continuous_annotation.update(**{"type": {10: "nonsense_heuristic"}})
     data = pd.DataFrame(
-        continuous_annotation.update(**{"type": {10: "nonsense_heuristic"}})
+        continuous_annotation
     )
     result = process_dict(data, user_dict)
 

--- a/tests_proc_dict.py
+++ b/tests_proc_dict.py
@@ -26,6 +26,21 @@ def discrete_annotation():
         "isPartOf": {1: "", 2: "", 3: "", 4: ""},
         "Decision": {1: "keep", 2: "keep", 3: "keep", 4: "keep"},
     }
+    
+    
+@pytest.fixture
+def participant_annotation():
+    return {
+        "dataset": {10: "ds000002"},
+        "column": {10: "participant_id"},
+        "type": {10: "str"},
+        "value": {10: ""},
+        "is_row": {10: True},
+        "description": {10: ""},
+        "controlled_term": {10: "nb:ParticipantID"},
+        "isPartOf": {10: ""},
+        "Decision": {10: "keep"},
+    }
 
 
 @pytest.fixture
@@ -150,3 +165,13 @@ def test_get_transform_heuristic(annotation, expected, continuous_annotation):
     df = pd.DataFrame(continuous_annotation)
     result = get_transform_heuristic(df)
     assert result[0] == expected
+    
+    
+def test_participant_id_column_goes_through(participant_annotation, user_dict):
+    df = pd.DataFrame(participant_annotation)
+    result = process_dict(df, user_dict)
+    assert result.get("participant_id") is not None
+    assert result.get("participant_id").get("Annotations") is not None
+    assert result.get("participant_id").get("Annotations").get("Identifies") is not None
+
+

--- a/tests_proc_dict.py
+++ b/tests_proc_dict.py
@@ -124,7 +124,7 @@ def test_bad_continuous_lacks_transformation(continuous_annotation, user_dict):
     )
     result = process_dict(data, user_dict)
 
-    assert result.get("age").get("Annotations", {}).get("Transformation") is None
+    assert result.get("age").get("Annotations") is None
 
 
 def test_describe_continuous(continuous_annotation):

--- a/tests_proc_dict.py
+++ b/tests_proc_dict.py
@@ -66,10 +66,7 @@ def drop_annotation(continuous_annotation):
 @pytest.fixture
 def user_dict():
     return {
-        "age": {
-            "Description": "age of the participant",
-            "Units": "years"
-        },
+        "age": {"Description": "age of the participant", "Units": "years"},
         "sex": {
             "Description": "gender of the participant",
             "Levels": {"M": "male", "F": "female"},
@@ -77,52 +74,64 @@ def user_dict():
     }
 
 
-def test_original_data_unchanged_when_no_annotation(drop_annotation, user_dict):
+def test_original_data_unchanged_when_no_annotation(
+    drop_annotation, user_dict
+):
     """Dropped annotations should not be added to the generated data dictionary"""
     data = pd.DataFrame(drop_annotation)
     result = process_dict(data, user_dict)
     assert result == user_dict
 
 
-def test_original_data_augmented_by_annotation(continuous_annotation, user_dict):
+def test_original_data_augmented_by_annotation(
+    continuous_annotation, user_dict
+):
     data = pd.DataFrame(continuous_annotation)
     result = process_dict(data, user_dict)
-    
+
     assert result.get("age", {}).get("Annotations") is not None
     assert result.get("sex") is not None
-    
-    
+
+
 def test_good_continuous_has_transformation(continuous_annotation, user_dict):
     data = pd.DataFrame(continuous_annotation)
     result = process_dict(data, user_dict)
-    
-    assert result.get("age").get("Annotations").get("Transformation") is not None
-    
-    
+
+    assert (
+        result.get("age").get("Annotations").get("Transformation") is not None
+    )
+
+
 def test_bad_continuous_has_transformation(continuous_annotation, user_dict):
-    data = pd.DataFrame(continuous_annotation.update(**{"type": {10: "nonsense_heuristic"}}))
+    data = pd.DataFrame(
+        continuous_annotation.update(**{"type": {10: "nonsense_heuristic"}})
+    )
     result = process_dict(data, user_dict)
-    
+
     assert result.get("age").get("Annotations").get("Transformation") is None
-    
-    
+
+
 def test_partof_annotation_is_processed(tool_annotation, user_dict):
     data = pd.DataFrame(tool_annotation)
     result = process_dict(data, user_dict)
-    
-    assert result.get("tool1") is not None
-    assert result.get("tool1").get("Annotations", {}).get("IsPartOf") is not None
-    
 
-@pytest.mark.parametrize("annotation,expected", [
-    ({'type': {10: "float64"}}, "nb:float"),
-    ({'type': {10: "int64"}}, "nb:int"),
-    ({'type': {10: "nb:bounded"}}, "nb:bounded"),
-    ({'type': {10: "nb:euro"}}, "nb:euro"),
-    ])
+    assert result.get("tool1") is not None
+    assert (
+        result.get("tool1").get("Annotations", {}).get("IsPartOf") is not None
+    )
+
+
+@pytest.mark.parametrize(
+    "annotation,expected",
+    [
+        ({"type": {10: "float64"}}, "nb:float"),
+        ({"type": {10: "int64"}}, "nb:int"),
+        ({"type": {10: "nb:bounded"}}, "nb:bounded"),
+        ({"type": {10: "nb:euro"}}, "nb:euro"),
+    ],
+)
 def test_get_transform_heuristic(annotation, expected, continuous_annotation):
     continuous_annotation.update(**annotation)
     df = pd.DataFrame(continuous_annotation)
     result = get_transform_heuristic(df)
     assert result[0] == expected
-    


### PR DESCRIPTION
Closes #17 

- adds functionality to add `"Transformation"` key to `age` columns
- has a function to map the annotated `type` column entries to our transformation names: https://www.neurobagel.org/documentation/dictionaries/#age
- ran black on it
- moved `describe_continuous` to be closer to other `describer` functions
- added tests
- fixed a bug with `is_tool` where checking whether emptystring is `null` was always true :cry: 

