### PR TITLE
[FIX] Process missing values separately

### DIFF
--- a/process_annotation_to_dict.py
+++ b/process_annotation_to_dict.py
@@ -181,8 +181,12 @@ def process_dict(ds_df: pd.DataFrame, user_dict: dict) -> dict:
     return user_dict
 
 
-def main():
-    annotated = pd.read_csv(MYPATH / "outputs/annotated_levels.tsv", sep="\t")
+def load_annotations(annotated_path: Path) -> pd.DataFrame:
+    return pd.read_csv(annotated_path, sep="\t", dtype=str, keep_default_na=False)
+
+
+def main(annotated_path: Path = MYPATH / "outputs/annotated_levels.tsv"):
+    annotated = load_annotations(annotated_path)
 
     for dataset, ds_df in annotated.groupby("dataset"):
         data_dict = fetch_data_dictionary(dataset=dataset)

--- a/process_annotation_to_dict.py
+++ b/process_annotation_to_dict.py
@@ -106,7 +106,7 @@ def describe_continuous(df: pd.DataFrame) -> dict:
     }
 
 
-def get_missing(df: pd.DataFrame) -> bool:
+def get_missing(df: pd.DataFrame) -> list:
     return [row["value"] for rid, row in df.iterrows() if row["controlled_term"] == "nb:MissingValue"]
 
 

--- a/process_annotation_to_dict.py
+++ b/process_annotation_to_dict.py
@@ -182,10 +182,10 @@ def process_dict(ds_df: pd.DataFrame, user_dict: dict) -> dict:
 
 
 def load_annotations(annotated_path: Path) -> pd.DataFrame:
-    return pd.read_csv(annotated_path, sep="\t", dtype=str, keep_default_na=False)
+    return pd.read_csv(annotated_path, sep="\t", dtype={'isPartOf': str, 'value': str, 'type': str}, keep_default_na=False)
 
 
-def main(annotated_path: Path = MYPATH / "outputs/annotated_levels.tsv"):
+def main(annotated_path: Path = MYPATH / "outputs/annotated_levels.tsv", output_path: Path = MYPATH / "outputs/data_dictionaries/"):
     annotated = load_annotations(annotated_path)
 
     for dataset, ds_df in annotated.groupby("dataset"):
@@ -198,7 +198,7 @@ def main(annotated_path: Path = MYPATH / "outputs/annotated_levels.tsv"):
             # print("Uhoh, this is not a valid dict", dataset)
             pass
         write_data_dict(
-            data_dict, MYPATH / "outputs/data_dictionaries/", name=dataset
+            data_dict, output_path, name=dataset
         )
     print("Tada!")
 

--- a/process_annotation_to_dict.py
+++ b/process_annotation_to_dict.py
@@ -43,6 +43,7 @@ def fetch_data_dictionary(dataset: str) -> dict:
             data_dict = json.load(f)
         return data_dict
     else:
+        print(f"cannot find {dataset} data dictionary at {get_dict_path(dataset)}")
         return {}
 
 
@@ -177,10 +178,10 @@ def process_dict(ds_df: pd.DataFrame, user_dict: dict) -> dict:
             continue
         if is_identifying(col_df):
             user_dict.setdefault(col, {}).update(**describe_identified(col_df))
-        elif is_discrete(col_df):
-            user_dict.setdefault(col, {}).update(**describe_discrete(col_df))
         elif is_tool(col_df):
             user_dict.setdefault(col, {}).update(**describe_tool(col_df))
+        elif is_discrete(col_df):
+            user_dict.setdefault(col, {}).update(**describe_discrete(col_df))
         else:
             user_dict.setdefault(col, {}).update(**describe_continuous(col_df))
 

--- a/process_annotation_to_dict.py
+++ b/process_annotation_to_dict.py
@@ -105,16 +105,24 @@ def describe_continuous(df: pd.DataFrame) -> dict:
     }
 
 
+def get_missing(df: pd.DataFrame) -> bool:
+    return [row["value"] for rid, row in df.iterrows() if row["controlled_term"] == "nb:MissingValue"]
+
+
 def describe_discrete(df: pd.DataFrame) -> dict:
-    return {
+    col_annotation = {
         "Annotations": {
             **describe_isabout(get_col_rows(df)["controlled_term"].item()),
             "Levels": {
                 row.value: describe_level(row.controlled_term)
-                for _, row in get_level_rows(df).iterrows()
+                for _, row in get_level_rows(df).iterrows() if not row["controlled_term"] == "nb:MissingValue"
             },
         }
     }
+    if missing := get_missing(df):
+        col_annotation["Annotations"]["MissingValues"] = missing
+
+    return col_annotation
 
 
 def describe_tool(df: pd.DataFrame) -> dict:

--- a/tests_proc_dict.py
+++ b/tests_proc_dict.py
@@ -1,7 +1,9 @@
+import json
+
 import pandas as pd
 import pytest
 
-from process_annotation_to_dict import process_dict, get_transform_heuristic, describe_continuous, load_annotations
+from process_annotation_to_dict import process_dict, get_transform_heuristic, describe_continuous, load_annotations, main
 
 
 @pytest.fixture
@@ -76,9 +78,24 @@ def missing_value():
 @pytest.fixture
 def missing_file(tmp_path):
     header = "\t".join(["dataset", "column", "type", "value", "is_row", "description", "controlled_term", "isPartOf", "Decision"])
-    row1 = "\t".join(["ds000002", "sex", "n/a", "nan", "True", "", "nb:MissingValue", "", "keep"])
+    row1 = "\t".join(["ds000002", "sex", "object", "n/a", "True", "", "nb:MissingValue", "", "keep"])
+    row2 = "\t".join(["ds000002", "sex", "n/a", "nan", "False", "", "nb:MissingValue", "", "keep"])
     with open(tmp_path / "missing.tsv", "w") as f:
-        f.write("\n".join([header, row1]))
+        f.write("\n".join([header, row1, row2]))
+
+    return tmp_path / "missing.tsv"
+
+
+@pytest.fixture
+def unusual_file(tmp_path):
+    header = "\t".join(["dataset", "column", "type", "value", "is_row", "description", "controlled_term", "isPartOf", "Decision"])
+    row1 = "\t".join(["ds000002", "sex", "object", "n/a", "True", "", "nb:Sex", "", "keep"])
+    row2 = "\t".join(["ds000002", "sex", "n/a", "nan", "False", "", "nb:Male", "", "keep"])
+    row3 = "\t".join(["ds000002", "sex", "n/a", "True", "False", "", "nb:Male", "", "keep"])
+    row4 = "\t".join(["ds000002", "sex", "n/a", "", "False", "", "nb:Male", "", "keep"])
+    row5 = "\t".join(["ds000002", "sex", "n/a", "n/a", "False", "", "nb:Male", "", "keep"])
+    with open(tmp_path / "missing.tsv", "w") as f:
+        f.write("\n".join([header, row1, row2, row3, row4, row5]))
 
     return tmp_path / "missing.tsv"
 
@@ -202,6 +219,18 @@ def test_participant_id_column_goes_through(participant_annotation, user_dict):
 
 def test_nan_is_read_as_string(missing_file):
     result = load_annotations(missing_file)
-    assert result.isPartOf[0] == ""
-    assert result.value[0] == "nan"
-    assert result.type[0] == "n/a"
+    assert result.isPartOf[1] == ""
+    assert result.value[1] == "nan"
+    assert result.type[1] == "n/a"
+
+
+def test_unusual_strings_are_identical_in_output(unusual_file, tmp_path):
+    out_path = tmp_path / "ds000002.json"
+    main(unusual_file, tmp_path)
+    result = json.loads(out_path.read_text()).get("sex", {}).get("Annotations", {}).get("Levels")
+
+    assert result is not None
+    assert "nan" in result and isinstance(result.get("nan"), dict)
+    assert "True" in result and isinstance(result.get("True"), dict)
+    assert "" in result and isinstance(result.get(""), dict)
+

--- a/tests_proc_dict.py
+++ b/tests_proc_dict.py
@@ -74,20 +74,6 @@ def missing_file(tmp_path):
 
 
 @pytest.fixture
-def unusual_file(tmp_path):
-    header = "\t".join(["dataset", "column", "type", "value", "is_row", "description", "controlled_term", "isPartOf", "Decision"])
-    row1 = "\t".join(["ds000002", "sex", "object", "n/a", "True", "", "nb:Sex", "", "keep"])
-    row2 = "\t".join(["ds000002", "sex", "n/a", "nan", "False", "", "nb:Male", "", "keep"])
-    row3 = "\t".join(["ds000002", "sex", "n/a", "True", "False", "", "nb:Male", "", "keep"])
-    row4 = "\t".join(["ds000002", "sex", "n/a", "", "False", "", "nb:Male", "", "keep"])
-    row5 = "\t".join(["ds000002", "sex", "n/a", "n/a", "False", "", "nb:Male", "", "keep"])
-    with open(tmp_path / "missing.tsv", "w") as f:
-        f.write("\n".join([header, row1, row2, row3, row4, row5]))
-
-    return tmp_path / "missing.tsv"
-
-
-@pytest.fixture
 def tool_annotation():
     return {
         "dataset": {102: "ds000009"},
@@ -209,17 +195,6 @@ def test_nan_is_read_as_string(missing_file):
     assert result.isPartOf[0] == ""
     assert result.value[0] == "n/a"
     assert result.type[0] == "object"
-
-
-def test_unusual_strings_are_identical_in_output(unusual_file, tmp_path):
-    out_path = tmp_path / "ds000002.json"
-    main(unusual_file, tmp_path)
-    result = json.loads(out_path.read_text()).get("sex", {}).get("Annotations", {}).get("Levels")
-
-    assert result is not None
-    assert "nan" in result and isinstance(result.get("nan"), dict)
-    assert "True" in result and isinstance(result.get("True"), dict)
-    assert "" in result and isinstance(result.get(""), dict)
 
 
 def test_missing_value_is_parsed_correctly(missing_file, tmp_path):

--- a/tests_proc_dict.py
+++ b/tests_proc_dict.py
@@ -223,25 +223,16 @@ def test_unusual_strings_are_identical_in_output(unusual_file, tmp_path):
 
 
 def test_missing_value_is_parsed_correctly(missing_file, tmp_path):
+    """
+    Ensure that values annotated with nb:MissingValue end up in "MissingValues"
+    and are not treated like normal controlled term mappings (i.e. end up in "Levels")
+    """
     out_path = tmp_path / "ds000002.json"
     main(missing_file, tmp_path)
     result = json.loads(out_path.read_text())
-
-    assert result == {
-  "sex": {
-    "Annotations": {
-      "IsAbout": {
-        "TermURL": "nb:Sex",
-        "Label": ""
-      },
-      "Levels": {
-        "m": {
-          "TermURL": "snomed:248153007",
-          "Label": ""
-        }
-      },
-        "MissingValues": ["nan"]
-    },
-    "Description": "There should have been a description here, but there wasn't. :("
-  }
-}
+    
+    annotations = result["sex"]["Annotations"]
+    
+    assert "m" in annotations["Levels"]
+    assert "nan" not in annotations["Levels"]
+    assert "nan" in annotations["MissingValues"]

--- a/tests_proc_dict.py
+++ b/tests_proc_dict.py
@@ -60,20 +60,6 @@ def continuous_annotation():
     }
 
 
-@pytest.fixture
-def missing_value():
-    return {
-        "dataset": {10: "ds000002"},
-        "column": {10: "sex"},
-        "type": {10: "n/a"},
-        "value": {10: "nan"},
-        "is_row": {10: True},
-        "description": {10: ""},
-        "controlled_term": {10: "nb:Age"},
-        "isPartOf": {10: ""},
-        "Decision": {10: "keep"},
-    }
-
 
 @pytest.fixture
 def missing_file(tmp_path):


### PR DESCRIPTION
Closes #23 

- when row term is assigned to `nb:MissingValue` -> do not put it into `"Levels"` but directly append to `MissingValues` array
- read columns for "value", "type" and "isPartOf" as string to about pandas converting types 
- change the order of column type checks in `process_dict` so `is_tool()` is checked before `is_discrete()` because the latter is so unspecific that it also captures `is_tool` cases (effectively rendering this category unaccessible if it is checked later)